### PR TITLE
use promise instead of callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ require("dotenv").config({
 ```javascript
   plugins: [
     {
-      resolve: "gatsby-source-all-readme",
+      resolve: "gatsby-source-gh-readme",
       options: {
         gitHubToken: `${process.env.GITHUB_API_TOKEN}`
       }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -39,8 +39,7 @@ exports.sourceNodes = (
   };
 
   // Gatsby expects sourceNodes to return a promise
-  return github.query(
-    `
+  return github.query(`
     query {
       viewer {
         name
@@ -68,9 +67,8 @@ exports.sourceNodes = (
           }
         }
       }
-    `,
-    null,
-    (res, err) => {
+    `)
+    .then((res) => {
       const { data } = res;
       const nodes = data.viewer.repositories.edges;
 
@@ -87,6 +85,5 @@ exports.sourceNodes = (
           createNode(nodeData);
         }
       });
-    }
-  ); // end github.query
+    });
 }; // exports.sourceNodes


### PR DESCRIPTION
If you use the callback signature node-github-graphql it doesn't return a promise.
I'm not sure if this has always been the case but in `gatsby@2.13.20` if you don't return a promise from `sourceNodes` no nodes are made.
